### PR TITLE
Convert to a full-fledged minor mode

### DIFF
--- a/ido-complete-space-or-hyphen.el
+++ b/ido-complete-space-or-hyphen.el
@@ -121,6 +121,10 @@ within a function by let-binding this to nil:
   (when ido-complete-space-or-hyphen-mode
     (ad-enable-advice 'ido-complete-space 'around 'ido-complete-space-or-hyphen)
     (ad-activate 'ido-complete-space)))
+(define-obsolete-variable-alias
+  'ido-complete-space-or-hyphen
+  'ido-complete-space-or-hyphen-mode
+  "ido-complete-space-or-hyphen 1.2")
 
 (defvar ido-complete-space-or-hyphen--insert-space nil
   "Internal variable to indicate whether SPACE should be inserted
@@ -177,12 +181,18 @@ It allows user press SPACE twice to insert real SPACE.
   "Enable ido-complete-space-or-hyphen"
   (interactive)
   (ido-complete-space-or-hyphen-mode 1))
+(make-obsolete
+ 'ido-complete-space-or-hyphen-enable
+ "use `(ido-complete-space-or-hyphen-mode 1)' instead.")
 
 ;;;###autoload
 (defun ido-complete-space-or-hyphen-disable ()
   "Disable ido-complete-space-or-hyphen"
   (interactive)
   (ido-complete-space-or-hyphen-mode 1))
+(make-obsolete
+ 'ido-complete-space-or-hyphen-enable
+ "use `(ido-complete-space-or-hyphen-mode 0)' instead.")
 
 (provide 'ido-complete-space-or-hyphen)
 

--- a/ido-complete-space-or-hyphen.el
+++ b/ido-complete-space-or-hyphen.el
@@ -6,7 +6,7 @@
 ;; Description: Complete SPACE or HYPHEN when type SPACE in ido
 ;; Created: 2012-11-07 13:58
 ;; Version: 1.1
-;; Last-Updated: Sun Apr 12 17:02:49 2015 (-0700)
+;; Last-Updated: Sun Apr 12 17:06:11 2015 (-0700)
 ;; URL: https://github.com/doitian/ido-complete-space-or-hyphen
 
 ;;; Licence:
@@ -115,7 +115,7 @@ within a function by let-binding this to nil:
 
     (let ((ido-complete-space-or-hyphen nil))
       (ido-completing-read ...))"
-  t
+  nil
   :global t
   :group 'ido
   (when ido-complete-space-or-hyphen-mode

--- a/ido-complete-space-or-hyphen.el
+++ b/ido-complete-space-or-hyphen.el
@@ -6,7 +6,7 @@
 ;; Description: Complete SPACE or HYPHEN when type SPACE in ido
 ;; Created: 2012-11-07 13:58
 ;; Version: 1.1
-;; Last-Updated: Sun Apr 12 17:06:11 2015 (-0700)
+;; Last-Updated: Sun Apr 12 17:24:59 2015 (-0700)
 ;; URL: https://github.com/doitian/ido-complete-space-or-hyphen
 
 ;;; Licence:
@@ -29,10 +29,10 @@
 ;;; Commentary:
 
 ;; The default behavior of ido SPACE key will try to insert SPACE if it makes
-;; sence (a.k.a, the comman part of all matches contains SPACE). Howerver,
+;; sense (a.k.a, the comman part of all matches contains SPACE). However,
 ;; when ido is used to complete lisp functions or variables, like what smex
 ;; does, HYPHEN is used as separator. This extension for ido inserts SPACE or
-;; HYPHEN whenever which one makes sence, just like what built-in M-x does.
+;; HYPHEN whenever either one makes sense, just like what built-in M-x does.
 ;;
 ;; Example:
 ;;
@@ -105,10 +105,10 @@
   "Toggle ido-complete-space-or-hyphen mode.
 
 The default behavior of ido SPACE key will try to insert SPACE if it makes
-sence (a.k.a, the comman part of all matches contains SPACE). Howerver,
+sense (a.k.a, the comman part of all matches contains SPACE). Howerver,
 when ido is used to complete lisp functions or variables, like what smex
 does, HYPHEN is used as separator. This extension for ido inserts SPACE or
-HYPHEN whenever which one makes sence, just like what built-in M-x does.
+HYPHEN whenever which one makes sense, just like what built-in M-x does.
 
 You can also temporary disable ido-complete-space-or-hyphen-mode
 within a function by let-binding this to nil:
@@ -128,7 +128,7 @@ within a function by let-binding this to nil:
 
 (defvar ido-complete-space-or-hyphen--insert-space nil
   "Internal variable to indicate whether SPACE should be inserted
-when both SPACE and HYPHEN make sence.
+when both SPACE and HYPHEN make sense.
 
 It allows user press SPACE twice to insert real SPACE.
 ")

--- a/ido-complete-space-or-hyphen.el
+++ b/ido-complete-space-or-hyphen.el
@@ -5,8 +5,8 @@
 ;; Filename: ido-complete-space-or-hyphen.el
 ;; Description: Complete SPACE or HYPHEN when type SPACE in ido
 ;; Created: 2012-11-07 13:58
-;; Version: 1.1
-;; Last-Updated: Sun Apr 12 17:24:59 2015 (-0700)
+;; Version: 1.2
+;; Last-Updated: Sun Apr 12 17:34:51 2015 (-0700)
 ;; URL: https://github.com/doitian/ido-complete-space-or-hyphen
 
 ;;; Licence:


### PR DESCRIPTION
This series of commits converts ido-complete-space-or-hyphen into ido-complete-space-or-hyphen-mode, which is a minor mode that adheres to the standard Emacs conventions for how minor modes should work. It also fixes a few spelling errors.
